### PR TITLE
Added get_dispute and get_disputes to v1.1

### DIFF
--- a/lib/Business/BalancedPayments/V11.pm
+++ b/lib/Business/BalancedPayments/V11.pm
@@ -131,6 +131,19 @@ method create_check_recipient(HashRef $rec) {
     return $res->{check_recipients}[0];
 }
 
+method get_dispute(Str $id) {
+    my $res = $self->get($self->_uri('disputes', $id));
+    return $res ? $res->{disputes}[0] : undef;
+}
+
+method get_disputes(Int :$limit, Int :$offset) {
+    my $res = $self->get($self->_uri('disputes'), {
+        (limit  => $limit ) x!! $limit,
+        (offset => $offset) x!! $offset,
+    });
+    return $res ? $res->{disputes} : undef;
+}
+
 method create_check_recipient_credit(HashRef $credit, HashRef :$check_recipient!) {
     my $rec_id = $check_recipient->{id}
         or croak 'The check_recipient hashref needs an id';


### PR DESCRIPTION
We only have disputes in our real marketplace, not in our test marketplace, so there was no good way to automatically test this.  However, I verified that both methods function correctly with different parameters manually.
