### PR TITLE
Added autopagination helper with callback support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,6 @@ my %WriteMakefileArgs = (
     "Method::Signatures" => 0,
     "Moo" => 0,
     "Moo::Role" => 0,
-    "Scalar::Util" => 0,
     "WebService::Client" => "0.0001"
   },
   "TEST_REQUIRES" => {
@@ -41,7 +40,7 @@ my %WriteMakefileArgs = (
     "strict" => 0,
     "warnings" => 0
   },
-  "VERSION" => "1.0402",
+  "VERSION" => "1.0500",
   "test" => {
     "TESTS" => "t/*.t"
   }
@@ -60,7 +59,6 @@ my %FallbackPrereqs = (
   "Method::Signatures" => 0,
   "Moo" => 0,
   "Moo::Role" => 0,
-  "Scalar::Util" => 0,
   "Test::Mock::LWP::Dispatch" => 0,
   "Test::Modern" => 0,
   "Test::More" => 0,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Business::BalancedPayments - Balanced Payments API bindings
 
 # VERSION
 
-version 1.0402
+version 1.0500
 
 # SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -8,7 +8,7 @@ license = Perl_5
 copyright_holder = Crowdtilt, Inc.
 copyright_year   = 2012
 
-version = 1.0402
+version = 1.0500
 
 [@Filter]
 -bundle = @Basic


### PR DESCRIPTION
This standardizes the `get_all` method to return a HashRef as well (instead of an ArrayRef) to standardize the method interfaces, and adds support for automatic pagination of records.  By passing in a callback subroutine as a named optional parameter called `$page_handler`, the method modifier is able to automatically fetch all of the records and process them as they become available, and reduce the need for chaining `get_all` manually to the `get_disputes` method:

``` perl
# Old way (still works)
my $disputes = $bp->get_all($bp->get_disputes({
    limit           => 100,
    'created_at[>]' => '2014-05-01T00:00:00',
})->{disputes};
print 'number of disputes total: ' . @$disputes;

# New way, more flexible because it can display progress to the client and process records when they become available
$bp->get_disputes({ limit => 100, 'created_at[>]' => '2014-05-01T00:00:00' },
    page_handler => sub {
        my ($res) = @_;
        print 'number of disputes per-page: ' . @{$res->{disputes}};
    });
```
